### PR TITLE
Add backslash to callback name

### DIFF
--- a/template/files/plugin/$slug.php.mustache
+++ b/template/files/plugin/$slug.php.mustache
@@ -46,4 +46,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 function {{slugSnakeCase}}_block_init() {
 	register_block_type_from_metadata( __DIR__ . '/build' );
 }
-add_action( 'init', __NAMESPACE__ . '{{slugSnakeCase}}_block_init' );
+add_action( 'init', __NAMESPACE__ . '\{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
For a plugin created with the following command
```
npx @wordpress/create-block multi-block-example-plugin --template @ryanwelcher/multi-block-template
```

I'm getting the following error

```
Fatal error: Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, function "MultiBlockExamplePluginmulti_block_example_plugin_block_init" not found or invalid function name in /var/www/html/wp-includes/class-wp-hook.php:324 Stack trace: #0 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array) #1 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #2 /var/www/html/wp-settings.php(695): do_action('init') #3 /var/www/html/wp-config.php(142): require_once('/var/www/html/w...') #4 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...') #5 /var/www/html/wp-admin/admin.php(34): require_once('/var/www/html/w...') #6 /var/www/html/wp-admin/post.php(12): require_once('/var/www/html/w...') #7 {main} thrown in /var/www/html/wp-includes/class-wp-hook.php on line 324
```

Adding a backslash to the callback solves this issue