### PR TITLE
loop to register all blocks

### DIFF
--- a/template/files/plugin/$slug.php.mustache
+++ b/template/files/plugin/$slug.php.mustache
@@ -44,6 +44,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function {{slugSnakeCase}}_block_init() {
-	register_block_type_from_metadata( __DIR__ . '/build' );
+	if (file_exists(__DIR__ . '/build/')) {
+		$block_json_files = glob(__DIR__ . '/build/*/block.json');
+		foreach ($block_json_files as $filename) {
+				$block_folder = dirname($filename);
+				register_block_type($block_folder);
+		};	
 }
+
 add_action( 'init', __NAMESPACE__ . '{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
The current implementation doesn't register the default block as the blocks are registered under `build/<%BLOCK-SLUG%>`
Any additional blocks aren't also registered, as they will be created with additional folders with their unique `<%BLOCK-SLUG%>` under `build` folder

This PR adds the code to register any `block.json` found for any subfolders under `build`